### PR TITLE
fix team links

### DIFF
--- a/index.html
+++ b/index.html
@@ -274,10 +274,10 @@
           <h5 class="text-lg font-bold">Anna Ko</h5>
           <p class="text-sm text-greyy">Software Engineer</p>
           <div class="flex">
-            <a class="flex-row px-5 " href="https: //github.com/annako-io">
+            <a class="flex-row px-5" href="https://github.com/annako-io" target="_blank">
               <img src="./img/icon-github.png" width="30px" alt="">
             </a>
-            <a href="https://www.linkedin.com/in/annako/">
+            <a href="https://www.linkedin.com/in/annako/" target="_blank">
               <img src="./img/icon-linkedin.png" width="30px" alt="">
             </a>
           </div>
@@ -289,10 +289,10 @@
           <h5 class="text-lg font-bold">Jamie Lee</h5>
           <p class="text-sm text-greyy">Software Engineer</p>
           <div class="flex">
-            <a class="flex-row px-5 " href="https: //github.com/jamieslee97">
+            <a class="flex-row px-5" href="https://github.com/jamieslee97" target="_blank">
               <img src="./img/icon-github.png" width="30px" alt="">
             </a>
-            <a href="https://www.linkedin.com/in/jamieslee2/">
+            <a href="https://www.linkedin.com/in/jamieslee2/" target="_blank">
               <img src="./img/icon-linkedin.png" width="30px" alt="">
             </a>
           </div>
@@ -304,10 +304,10 @@
           <h5 class="text-lg font-bold">Katrina McDonagh</h5>
           <p class="text-sm text-greyy">Software Engineer</p>
           <div class="flex">
-            <a class="flex-row px-5 " href="https: //github.com/katmcd5">
+            <a class="flex-row px-5" href="https://github.com/katmcd5" target="_blank">
               <img src="./img/icon-github.png" width="30px" alt="">
             </a>
-            <a href="https://www.linkedin.com/in/katrina-mcdonagh/">
+            <a href="https://www.linkedin.com/in/katrina-mcdonagh/" target="_blank">
               <img src="./img/icon-linkedin.png" width="30px" alt="">
             </a>
           </div>
@@ -319,10 +319,10 @@
           <h5 class="text-lg font-bold">Michael Arita</h5>
           <p class="text-sm text-greyy">Software Engineer</p>
           <div class="flex">
-            <a class="flex-row px-5 " href="https: //github.com/MichaelArita">
+            <a class="flex-row px-5" href="https://github.com/MichaelArita" target="_blank">
               <img src="./img/icon-github.png" width="30px" alt="">
             </a>
-            <a href="https://www.linkedin.com/in/michael-s-arita/">
+            <a href="https://www.linkedin.com/in/michael-s-arita/" target="_blank">
               <img src="./img/icon-linkedin.png" width="30px" alt="">
             </a>
           </div>
@@ -334,10 +334,10 @@
           <h5 class="text-lg font-bold">Nancy Yu</h5>
           <p class="text-sm text-greyy">Software Engineer</p>
           <div class="flex">
-            <a class="flex-row px-5 " href="https: //github.com/paynah">
+            <a class="flex-row px-5" href="https://github.com/paynah" target="_blank">
               <img src="./img/icon-github.png" width="30px" alt="">
             </a>
-            <a href="https://www.linkedin.com/in/nancy-yu3/">
+            <a href="https://www.linkedin.com/in/nancy-yu3/" target="_blank">
               <img src="./img/icon-linkedin.png" width="30px" alt="">
             </a>
           </div>


### PR DESCRIPTION
**Fix for team links**
- GitHub link had an space between http: // which was causing the link to be broken.
- Added target="_blank" to open links in a new page.